### PR TITLE
Set supported platform to Linux amd64

### DIFF
--- a/.changeset/bumpy-needles-post.md
+++ b/.changeset/bumpy-needles-post.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.cell-ranger': patch
+---
+
+Set supported platform to Linux amd64

--- a/block/package.json
+++ b/block/package.json
@@ -41,7 +41,8 @@
         "url": "https://milaboratories.com/",
         "logo": "file:../logos/organization-logo.png"
       },
-      "marketplaceRanking": 12900
+      "marketplaceRanking": 12900,
+      "supportedPlatforms": ["linux-x64"]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Cell Ranger system requirements https://www.10xgenomics.com/support/software/cell-ranger/downloads/cr-system-requirements
Possible supported platform values: https://github.com/milaboratory/platforma/blob/f0e89a9ad6ebf7b3621c9bbf6b7a9fcc18d7e96e/lib/model/middle-layer/src/block_meta/block_meta.ts#L10-L15