### PR TITLE
Add memory headroom to Cell Ranger --localmem flag

### DIFF
--- a/.changeset/fix-cellranger-memory-headroom.md
+++ b/.changeset/fix-cellranger-memory-headroom.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.cell-ranger.workflow': patch
+---
+
+Add memory headroom to Cell Ranger --localmem flag to prevent OOM kills in Docker containers

--- a/workflow/src/cell-ranger.tpl.tengo
+++ b/workflow/src/cell-ranger.tpl.tengo
@@ -103,7 +103,7 @@ self.body(func(inputs) {
 		arg("--create-bam=false").
 		arg("--id=sample").
 		argWithVar("--localcores={system.cpu}").
-		argWithVar("--localmem={system.ram.gb}").
+		argWithVar("--localmem={int(max(min(system.ram.gb*90/100,system.ram.gb-2),system.ram.gb*50/100))}").
 		saveFile("sample/outs/web_summary.html").
 		saveFile("sample/outs/filtered_feature_bc_matrix/barcodes.tsv.gz").
 		saveFile("sample/outs/filtered_feature_bc_matrix/features.tsv.gz").


### PR DESCRIPTION
## Summary

- Cell Ranger was receiving 100% of allocated RAM via `--localmem={system.ram.gb}`, leaving zero headroom for OS overhead, temp files, and I/O buffers in Docker containers, causing OOM kills
- New formula: `max(min(R*90/100, R-2), R*50/100)` — reserves ~10% or at least 2 GB, with a floor of 50%

## Test plan

- [ ] Run Cell Ranger block with default 64 GB allocation in Docker — verify no OOM
- [ ] Verify `--localmem` resolves to expected value (e.g., 57 for 64 GB allocation)