### PR TITLE
Bump unique-Ensembl-Ids pt workflow mem 4 GiB -> 16 GiB

### DIFF
--- a/.changeset/bump-unique-genes-pt-mem.md
+++ b/.changeset/bump-unique-genes-pt-mem.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.cell-ranger.workflow": patch
+---
+
+Bump the unique-Ensembl-Ids pt workflow from 4 GiB to 16 GiB. On large
+datasets the polars-pf reader yielded batches up to ~17.5M rows before the
+groupBy host process OOM'd at the previous 4 GiB ceiling. 16 GiB clears the
+peak with headroom for polars' streaming-engine bookkeeping.

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -74,7 +74,7 @@ self.body(func(inputs) {
 
 	// Use ptabler directly on pFrame data to extract unique Ensembl IDs
 	// Pass the pFrame using p.full() and access the gene axis by name
-	ptWf := pt.workflow().mem("4GiB").cpu(1)
+	ptWf := pt.workflow().mem("16GiB").cpu(1)
 	axesDf := ptWf.frame(pt.p.full(rawCountsPfBuilt))
 	groupedDf := axesDf.select(pt.axis("pl7.app/rna-seq/geneId").alias("Ensembl Id")).groupBy("Ensembl Id").agg(pt.col("Ensembl Id").count().alias("_count"))
 	uniqueGeneIdsDf := groupedDf.select("Ensembl Id")


### PR DESCRIPTION
## Summary
- Bump `pt.workflow().mem("4GiB")` -> `mem("16GiB")` for the unique-Ensembl-Ids step in `process.tpl.tengo:77`.

## Why
Client report: large dataset OOMed during the gene-symbols path. Logs showed `polars_pf` `yielding batch at offset` lines up to ~17.5M rows, then crash. That source feeds the explicit `pt.workflow` consumer doing `groupBy("Ensembl Id").count()` over the joined long-format counts pframe; the pt step was hardcoded to 4 GiB while every other pt-using step in the template threads the user-supplied budget.

Raw working set is small (~1 GiB on the wire, ~30K-key hash-agg state) but polars' streaming engine + the custom IO source's batch buffering inflate the peak well beyond that — 4 GiB sits inside the noise floor. 16 GiB clears it with headroom; bumping further to the full per-step budget felt overkill for a step that runs briefly.

## Test plan
- [ ] Re-run the failing client dataset; confirm the gene-symbols stage completes past the previous ~17.5M-row mark.